### PR TITLE
Using vm.Script instead of AsyncFunction

### DIFF
--- a/src/executor.js
+++ b/src/executor.js
@@ -1,12 +1,11 @@
-const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const { Script } = require("vm");
 /**
- * Executes code, supports async/await syntax.
- * @param {string} code Code to execute
- * @param {[x: string]: any} opts Passed variables
+ * Executes code, doesn't support async/await syntax.
+ * @param {Script} script Code to execute
+ * @param {[x: string]: any} opts Passed variables (contextified!)
  * @returns {Promise} Result
  */
-module.exports = (code, opts) =>
-	AsyncFunction(...Object.keys(opts), `return ${code};`).apply(
-		null,
-		Object.values(opts)
-	);
+module.exports = {
+	compile: code => new Script(code),
+	exec: (script, opts) => script.runInContext(opts)
+};


### PR DESCRIPTION
Pros:
- The Function constructor is unsafe
- The current `return ${code};` doesn't allow multiple lines of code (unless IIFEs are used).

Cons:
- This is about 2x slower.
- vm.Script does *not* support top-level await.